### PR TITLE
Remove jdeploy-maven-plugin from project templates

### DIFF
--- a/projects/javafx/pom.xml
+++ b/projects/javafx/pom.xml
@@ -14,18 +14,4 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.main.class>{{ packageName }}.{{ mainClass }}</maven.compiler.main.class>
     </properties>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>ca.weblite</groupId>
-                <artifactId>jdeploy-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>jdeploy</id> <!-- Same ID as in parent -->
-                        <!-- No phase or goals: this effectively disables the execution -->
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/projects/picocli/pom.xml
+++ b/projects/picocli/pom.xml
@@ -14,8 +14,6 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <picocli.version>4.7.6</picocli.version>
-    <jdeploy.maven.plugin.version>1.0.8</jdeploy.maven.plugin.version>
-    <jdeploy.version>4.0.26</jdeploy.version>
   </properties>
   <dependencies>
     <dependency>
@@ -64,21 +62,6 @@
                 ${project.build.directory}/libs
               </outputDirectory>
             </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>ca.weblite</groupId>
-        <artifactId>jdeploy-maven-plugin</artifactId>
-        <version>${jdeploy.maven.plugin.version}</version>
-        <executions>
-          <execution>
-            <id>jdeploy</id>
-            <phase>package</phase>
-            <goals>
-              <goal>sync-package-json</goal>
-            </goals>
           </execution>
         </executions>
       </plugin>

--- a/projects/swing/pom.xml
+++ b/projects/swing/pom.xml
@@ -13,8 +13,6 @@
     <java.version>{{ javaVersion }}</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <jdeploy.maven.plugin.version>1.0.8</jdeploy.maven.plugin.version>
-    <jdeploy.version>4.0.26</jdeploy.version>
   </properties>
   <dependencies>
     <dependency>
@@ -58,21 +56,6 @@
                 ${project.build.directory}/libs
               </outputDirectory>
             </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>ca.weblite</groupId>
-        <artifactId>jdeploy-maven-plugin</artifactId>
-        <version>${jdeploy.maven.plugin.version}</version>
-        <executions>
-          <execution>
-            <id>jdeploy</id>
-            <phase>package</phase>
-            <goals>
-              <goal>sync-package-json</goal>
-            </goals>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
## Summary
- Removed `jdeploy-maven-plugin` from the **javafx**, **swing**, and **picocli** project templates
- Also removed the now-unused `jdeploy.maven.plugin.version` and `jdeploy.version` properties from swing and picocli templates
- The plugin is not helpful and is actually harmful, as discussed in https://github.com/shannah/jdeploy/discussions/447#discussioncomment-16295138

## Test plan
- [ ] Verify that new projects created from the javafx, swing, and picocli templates build successfully without the plugin
- [ ] Confirm no other templates reference `jdeploy-maven-plugin`

https://claude.ai/code/session_01BdXyscdoM5GZ6DRzZUEj2N